### PR TITLE
DDST-401: Use the renamed trait.

### DIFF
--- a/tests/src/Traits/IslandoraContentTypeTestTraits.php
+++ b/tests/src/Traits/IslandoraContentTypeTestTraits.php
@@ -9,7 +9,7 @@ use Drupal\media\MediaInterface;
 use Drupal\media\MediaTypeInterface;
 use Drupal\node\NodeInterface;
 use Drupal\node\NodeTypeInterface;
-use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
+use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
 use Drupal\Tests\media\Traits\MediaTypeCreationTrait;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\test_support\Traits\Installs\InstallsModules;
@@ -20,7 +20,7 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
  * Useful test traits for Islandora. Creates Islanodra node, media and files.
  */
 trait IslandoraContentTypeTestTraits {
-  use EntityReferenceTestTrait;
+  use EntityReferenceFieldCreationTrait;
   use ContentTypeCreationTrait;
   use MediaTypeCreationTrait;
   use InteractsWithEntities;


### PR DESCRIPTION
See: https://www.drupal.org/node/3401941

Technically, might constitute a `major` bump, given the new trait didn't exist prior; however, given the trivial nature of the renaming and the fact that it's just part of testing, inclined to leave lower.